### PR TITLE
Add OTP25 to CI matrix

### DIFF
--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         elixir: ["1.13.4", "1.14.2"]
-        otp: ["24.3.4"]
+        otp: ["24.3.4", "25.1.2"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/elixir-dialyzer.yml
+++ b/.github/workflows/elixir-dialyzer.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         elixir: ["1.13.4", "1.14.2"]
-        otp: ["24.3.4"]
+        otp: ["24.3.4", "25.1.2"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/elixir-quality-checks.yml
+++ b/.github/workflows/elixir-quality-checks.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         elixir: ["1.13.4", "1.14.2"]
-        otp: ["24.3.4"]
+        otp: ["24.3.4", "25.1.2"]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
In order to verify compatibility with all in-use OTP versions, add OTP25 to the CI matrix.